### PR TITLE
Extend Airflow 3 support bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ airflow = [
     "apache-airflow-providers-standard",
 ]
 airflow3 = [
-    "apache-airflow>=3,<3.2",
+    "apache-airflow>=3,<3.4",
     "apache-airflow-providers-ssh",
     "apache-airflow-providers-standard",
 ]


### PR DESCRIPTION
Allow Airflow 3 installations through 3.3 by widening the `airflow3` optional dependency bound to `<3.4`. The `airflow-pydantic` runtime dependency remains capped below 1.6 for the planned release sequence.

Local checks: `make lint`; 34 tests passed and 16 skipped.