### PR TITLE
Add Airflow version generation CLI

### DIFF
--- a/airflow_config/cli.py
+++ b/airflow_config/cli.py
@@ -1,0 +1,29 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+from airflow_config import load_config
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Generate Airflow DAG files from an airflow-config YAML file.")
+    parser.add_argument("config", type=Path, help="Path to the airflow-config YAML file")
+    parser.add_argument("-o", "--output-dir", type=Path, required=True, help="Directory for generated DAG files")
+    parser.add_argument("--airflow-version", type=int, choices=(2, 3), required=True, help="Target Airflow major version")
+    parser.add_argument("--override", action="append", default=[], help="Hydra override; may be specified more than once")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parser().parse_args(argv)
+    config_path = args.config.resolve()
+    config = load_config(
+        config_path.parent.name,
+        config_path.name,
+        overrides=args.override,
+        basepath=str(config_path),
+    )
+    config.generate(args.output_dir, airflow_major_version=args.airflow_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/airflow_config/configuration/base.py
+++ b/airflow_config/configuration/base.py
@@ -1,9 +1,10 @@
 import os
 import sys
 from copy import deepcopy
-from inspect import currentframe
+from inspect import currentframe, signature
 from logging import getLogger
 from pathlib import Path
+from typing import Literal
 
 from airflow_pydantic import BaseModel, Dag, DagArgs, TaskArgs
 from airflow_pydantic.airflow import EmptyOperator
@@ -210,13 +211,14 @@ class Configuration(BaseModel):
                 dags.extend(factory())
         return dags
 
-    def _generated_files(self):
+    def _generated_files(self, airflow_major_version: Literal[2, 3]):
         generated = {}
         for extension in (self.extensions or {}).values():
             factory = getattr(extension, "generated_files", None)
             if not factory:
                 continue
-            for filename, source in factory().items():
+            kwargs = {"airflow_major_version": airflow_major_version} if "airflow_major_version" in signature(factory).parameters else {}
+            for filename, source in factory(**kwargs).items():
                 if filename in generated and generated[filename] != source:
                     raise ValueError(f"Extensions generated conflicting files named {filename}")
                 generated[filename] = source
@@ -257,12 +259,12 @@ class Configuration(BaseModel):
             dag_instance.fileloc = str(dag_path)
             cur_frame.f_globals[dag.dag_id] = dag_instance
 
-    def generate(self, dir: Path | str | None = None):
+    def generate(self, dir: Path | str | None = None, *, airflow_major_version: Literal[2, 3]):
         dir = dir or Path.cwd()
         dir_path = Path(dir)
         dir_path.mkdir(parents=True, exist_ok=True)
 
-        generated_files = self._generated_files()
+        generated_files = self._generated_files(airflow_major_version)
         configured_dag_files = {f"{dag_id}.py" for dag_id in (self.dags or {})}
         conflicts = configured_dag_files & generated_files.keys()
         if conflicts:
@@ -271,7 +273,7 @@ class Configuration(BaseModel):
 
         for dag_id, dag in self.dags.items():
             if dag.tasks:
-                rendered = dag.render()
+                rendered = dag.render(airflow_major_version=airflow_major_version)
                 dag_path = dir_path / f"{dag_id}.py"
                 if dag_path.exists() and dag_path.read_text() == rendered:
                     continue

--- a/airflow_config/tests/setups/factory/test_factory_render.py
+++ b/airflow_config/tests/setups/factory/test_factory_render.py
@@ -270,7 +270,7 @@ def test_render():
 def test_generate():
     conf = load_config("config", "factory")
     with TemporaryDirectory() as tmp_dir:
-        conf.generate(tmp_dir)
+        conf.generate(tmp_dir, airflow_major_version=2)
         assert sorted(listdir(tmp_dir)) == ["example_dag.py", "example_dag2.py"]
         assert (Path(tmp_dir) / "example_dag.py").read_text() == RENDERED_DAG
 
@@ -283,7 +283,7 @@ def test_render_multi():
 def test_generate_multi():
     conf = load_config("config", "multi")
     with TemporaryDirectory() as tmp_dir:
-        conf.generate(tmp_dir)
+        conf.generate(tmp_dir, airflow_major_version=2)
         assert sorted(listdir(tmp_dir)) == ["example_dag.py", "example_dag2.py"]
         assert (Path(tmp_dir) / "example_dag.py").read_text() == RENDERED_DAG_MULTI
         assert (Path(tmp_dir) / "example_dag2.py").read_text() == RENDERED_DAG_MULTI2
@@ -292,7 +292,7 @@ def test_generate_multi():
 def test_generate_type_override():
     conf = load_config("config", "type_override")
     with TemporaryDirectory() as tmp_dir:
-        conf.generate(tmp_dir)
+        conf.generate(tmp_dir, airflow_major_version=2)
         assert sorted(listdir(tmp_dir)) == ["example_dag.py", "example_dag2.py"]
         assert (Path(tmp_dir) / "example_dag.py").read_text() == RENDERED_DAG_TYPE_OVERRIDE
         assert (Path(tmp_dir) / "example_dag2.py").read_text() == RENDERED_DAG_TYPE_OVERRIDE2
@@ -314,7 +314,7 @@ def test_render_self_balancer_query():
         cfg = load_config("config", "balancer")
         assert cfg.dags["example_dag"].tasks["task_1"].ssh_hook.remote_host == "server2.local"
         with TemporaryDirectory() as tmp_dir:
-            cfg.generate(tmp_dir)
+            cfg.generate(tmp_dir, airflow_major_version=2)
             assert sorted(listdir(tmp_dir)) == [*POOL_MANAGER_FILES, "example_dag.py"]
             if AIRFLOW_PYDANTIC_VERSION >= (1, 6, 2):
                 expected = RENDERED_DAG_BALANCER
@@ -328,7 +328,7 @@ def test_render_self_balancer_query():
 def test_render_self_reference():
     cfg = load_config("config", "self_reference")
     with TemporaryDirectory() as tmp_dir:
-        cfg.generate(tmp_dir)
+        cfg.generate(tmp_dir, airflow_major_version=2)
         assert sorted(listdir(tmp_dir)) == [*POOL_MANAGER_FILES, "example_dag.py"]
         assert (Path(tmp_dir) / "example_dag.py").read_text() == RENDERED_DAG_SELF_REFERENCE
 
@@ -336,6 +336,6 @@ def test_render_self_reference():
 def test_render_templates():
     cfg = load_config("config", "templates")
     with TemporaryDirectory() as tmp_dir:
-        cfg.generate(tmp_dir)
+        cfg.generate(tmp_dir, airflow_major_version=2)
         assert sorted(listdir(tmp_dir)) == ["example_dag.py"]
         assert (Path(tmp_dir) / "example_dag.py").read_text() == RENDERED_DAG_TEMPLATES

--- a/airflow_config/tests/test_cli.py
+++ b/airflow_config/tests/test_cli.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from airflow_config.cli import main
+
+
+def test_generate_cli_selects_airflow_version():
+    config_path = Path("config/prod.yaml").resolve()
+
+    with patch("airflow_config.cli.load_config") as load_config:
+        main(
+            [
+                str(config_path),
+                "--output-dir",
+                "generated_dags",
+                "--airflow-version",
+                "3",
+                "--override",
+                "dags.example.schedule=None",
+            ]
+        )
+
+    load_config.assert_called_once_with(
+        "config",
+        "prod.yaml",
+        overrides=["dags.example.schedule=None"],
+        basepath=str(config_path),
+    )
+    load_config.return_value.generate.assert_called_once_with(Path("generated_dags"), airflow_major_version=3)

--- a/airflow_config/tests/test_managed_dags.py
+++ b/airflow_config/tests/test_managed_dags.py
@@ -18,6 +18,14 @@ class ManagedDagExtension(BaseModel):
         return self.dags
 
 
+class VersionedManagedDagExtension(ManagedDagExtension):
+    version: int | None = None
+
+    def generated_files(self, airflow_major_version):
+        self.version = airflow_major_version
+        return self.files
+
+
 class ManagedDag:
     def __init__(self, dag_id, instance):
         self.dag_id = dag_id
@@ -37,7 +45,7 @@ def test_generate_writes_extension_managed_files(tmp_path):
         },
     )
 
-    config.generate(tmp_path)
+    config.generate(tmp_path, airflow_major_version=2)
 
     assert (tmp_path / "managed_runtime.py").read_text() == "RUNTIME = True\n"
     assert (tmp_path / "managed_dag.py").read_text() == "DAG = True\n"
@@ -70,4 +78,12 @@ def test_generate_rejects_conflicting_extension_files(tmp_path):
     )
 
     with pytest.raises(ValueError, match="Extensions generated conflicting files named managed.py"):
-        config.generate(tmp_path)
+        config.generate(tmp_path, airflow_major_version=2)
+
+
+def test_generate_passes_airflow_version_to_extensions(tmp_path):
+    config = Configuration(dags={}, extensions={"test": VersionedManagedDagExtension()})
+
+    config.generate(tmp_path, airflow_major_version=3)
+
+    assert config.extensions["test"].version == 3

--- a/docs/src/how-to.md
+++ b/docs/src/how-to.md
@@ -73,11 +73,18 @@ Write one deterministic file per configured DAG:
 from airflow_config import load_config
 
 config = load_config("config", "prod")
-config.generate("generated_dags")
+config.generate("generated_dags", airflow_major_version=3)
 ```
 
 Commit or deploy the generated directory when DAG review and an Airflow runtime
 without Hydra are preferred. Unchanged files are not rewritten.
+
+To generate without installing Airflow, use the command-line interface and select
+the target major version explicitly:
+
+```console
+airflow-config config/prod.yaml --output-dir generated_dags --airflow-version 3
+```
 
 ## How to generate DAGs in memory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ airflow3 = [
 airflow-config-viewer = "airflow_config.ui.airflow:AirflowConfigViewerPlugin"
 
 [project.scripts]
+airflow-config = "airflow_config.cli:main"
 airflow-config-viewer = "airflow_config.ui.standalone:main"
 
 [project.urls]


### PR DESCRIPTION
## Description

Require an explicit Airflow 2 or 3 target for file generation and add an airflow-config command-line entry point. Propagate the selected target through configured DAGs and version-aware generated-file extensions while preserving existing extensions. Keep in-memory generation dependent on installed Airflow detection.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (make lint)
- [x] Tests pass (make test)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)