### PR TITLE
Add --import to the generation CLI

### DIFF
--- a/airflow_config/cli.py
+++ b/airflow_config/cli.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser
+from importlib import import_module
 from pathlib import Path
 
 from airflow_config import load_config
@@ -10,11 +11,21 @@ def _parser() -> ArgumentParser:
     parser.add_argument("-o", "--output-dir", type=Path, required=True, help="Directory for generated DAG files")
     parser.add_argument("--airflow-version", type=int, choices=(2, 3), required=True, help="Target Airflow major version")
     parser.add_argument("--override", action="append", default=[], help="Hydra override; may be specified more than once")
+    parser.add_argument(
+        "--import",
+        dest="imports",
+        action="append",
+        default=[],
+        metavar="MODULE",
+        help="Module to import before loading the config, e.g. to register OmegaConf resolvers; may be specified more than once",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> None:
     args = _parser().parse_args(argv)
+    for module in args.imports:
+        import_module(module)
     config_path = args.config.resolve()
     config = load_config(
         config_path.parent.name,

--- a/airflow_config/tests/test_cli.py
+++ b/airflow_config/tests/test_cli.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from airflow_config.cli import main
 
@@ -27,3 +27,28 @@ def test_generate_cli_selects_airflow_version():
         basepath=str(config_path),
     )
     load_config.return_value.generate.assert_called_once_with(Path("generated_dags"), airflow_major_version=3)
+
+
+def test_generate_cli_imports_modules_before_loading():
+    config_path = Path("config/prod.yaml").resolve()
+
+    with (
+        patch("airflow_config.cli.import_module") as import_module,
+        patch("airflow_config.cli.load_config") as load_config,
+    ):
+        import_module.side_effect = lambda module: load_config.assert_not_called()
+        main(
+            [
+                str(config_path),
+                "--output-dir",
+                "generated_dags",
+                "--airflow-version",
+                "3",
+                "--import",
+                "my_resolvers",
+                "--import",
+                "my_other_resolvers",
+            ]
+        )
+
+    assert import_module.call_args_list == [call("my_resolvers"), call("my_other_resolvers")]


### PR DESCRIPTION
Configs that rely on custom OmegaConf resolvers cannot be generated through the CLI, because nothing imports the module that registers them. Allow the importing module to be named on the command line, repeatably, before the config is loaded.