### PR TITLE
Add working directory to CLI import path

### DIFF
--- a/airflow_config/cli.py
+++ b/airflow_config/cli.py
@@ -1,3 +1,4 @@
+import sys
 from argparse import ArgumentParser
 from importlib import import_module
 from pathlib import Path
@@ -24,6 +25,9 @@ def _parser() -> ArgumentParser:
 
 def main(argv: list[str] | None = None) -> None:
     args = _parser().parse_args(argv)
+    cwd = str(Path.cwd())
+    if cwd not in sys.path:
+        sys.path.append(cwd)
     for module in args.imports:
         import_module(module)
     config_path = args.config.resolve()

--- a/airflow_config/tests/test_cli.py
+++ b/airflow_config/tests/test_cli.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from unittest.mock import call, patch
 
@@ -52,3 +53,26 @@ def test_generate_cli_imports_modules_before_loading():
         )
 
     assert import_module.call_args_list == [call("my_resolvers"), call("my_other_resolvers")]
+
+
+def test_generate_cli_adds_current_directory_to_python_path(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "path", sys.path.copy())
+
+    with (
+        patch("airflow_config.cli.import_module"),
+        patch("airflow_config.cli.load_config"),
+    ):
+        main(
+            [
+                "config/prod.yaml",
+                "--output-dir",
+                "generated_dags",
+                "--airflow-version",
+                "3",
+                "--import",
+                "my_resolvers",
+            ]
+        )
+
+    assert sys.path[-1] == str(tmp_path)


### PR DESCRIPTION
## Description

Append the resolved current working directory to `sys.path` before importing requested modules or loading configuration.

Console-script entry points otherwise use the script installation directory as their initial import path. That prevents locally defined resolver and extension modules from being found, unlike Airflow's DAG bundle import behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint-py`)
- [x] Tests pass (`python -m pytest -q`)
- [x] New tests added for new functionality
- [ ] Documentation updated (not applicable)
- [ ] Changelog / version bump (not applicable)
