### PR TITLE
Fix dags folder resolution and skip unreadable yaml files

### DIFF
--- a/airflow_config/tests/test_ui.py
+++ b/airflow_config/tests/test_ui.py
@@ -70,6 +70,29 @@ class TestPluginFunctions:
         )
 
 
+class TestPluginFunctionsDagsFolder:
+    def test_get_dags_folder_prefers_environment(self, monkeypatch):
+        from airflow_config.ui.functions import get_dags_folder
+
+        monkeypatch.setenv("AIRFLOW__CORE__DAGS_FOLDER", "/from/env")
+        assert get_dags_folder() == "/from/env"
+
+    def test_get_dags_folder_falls_back_to_airflow_config(self, has_airflow, monkeypatch):
+        from airflow.configuration import conf
+
+        from airflow_config.ui.functions import get_dags_folder
+
+        monkeypatch.delenv("AIRFLOW__CORE__DAGS_FOLDER", raising=False)
+        assert get_dags_folder() == conf.getsection("core").get("dags_folder")
+
+    def test_get_yaml_files_skips_undecodable_files(self, tmp_path):
+        from airflow_config.ui.functions import get_yaml_files
+
+        (tmp_path / "good.yaml").write_text("_target_: airflow_config.Configuration\n")
+        (tmp_path / "bad.yaml").write_bytes(b"\xff\xfe\x00\x81")
+        assert get_yaml_files(tmp_path) == [tmp_path / "good.yaml"]
+
+
 class TestStandaloneUI:
     def test_standalone_ui(self):
         from airflow_config.ui.standalone import build_app

--- a/airflow_config/ui/airflow.py
+++ b/airflow_config/ui/airflow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import ClassVar
 
@@ -15,13 +14,12 @@ try:
     from airflow.api_fastapi.auth.managers.models.resource_details import AccessView
     from airflow.api_fastapi.core_api.security import requires_access_view
 except ImportError:
-    from airflow.configuration import conf
     from airflow.security import permissions
     from airflow.www.auth import has_access
     from flask import Blueprint, request
     from flask_appbuilder import BaseView, expose
 
-    from .functions import get_configs_from_yaml, get_yaml_files
+    from .functions import get_configs_from_yaml, get_dags_folder, get_yaml_files
 
     class AirflowConfigViewerPluginView(BaseView):
         """Creating a Flask-AppBuilder View"""
@@ -46,7 +44,7 @@ except ImportError:
         def home(self):
             """Create default view"""
             # Locate the dags folder
-            dags_folder = os.environ.get("AIRFLOW__CORE__DAGS_FOLDER", conf.getsection("core").get("dags_folder"))
+            dags_folder = get_dags_folder()
             if not dags_folder:
                 return self.render_template("airflow_config/404.html")
             yamls = get_yaml_files(dags_folder=dags_folder)

--- a/airflow_config/ui/functions.py
+++ b/airflow_config/ui/functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from logging import getLogger
 from pathlib import Path
 
@@ -9,10 +10,37 @@ from airflow_config import ConfigNotFoundError, load_config
 
 __all__ = (
     "get_configs_from_yaml",
+    "get_dags_folder",
     "get_yaml_files",
 )
 
 log = getLogger(__name__)
+
+
+def get_dags_folder() -> str | None:
+    """Resolve the dags folder from the environment, falling back to the Airflow config.
+
+    Returns None when Airflow is unavailable, so the standalone viewer can supply its own default.
+    """
+    dags_folder = os.environ.get("AIRFLOW__CORE__DAGS_FOLDER")
+    if dags_folder:
+        return dags_folder
+    try:
+        from airflow.configuration import conf
+
+        return (conf.getsection("core") or {}).get("dags_folder")
+    except Exception:
+        log.debug("Could not read dags_folder from the Airflow configuration", exc_info=True)
+        return None
+
+
+def _read_text(path: Path) -> str:
+    """Read a yaml file, skipping any that cannot be decoded or accessed."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        log.debug(f"Skipping unreadable file {path}", exc_info=True)
+        return ""
 
 
 def get_configs_from_yaml(yaml: str, overrides: list[str]) -> list[str]:
@@ -35,7 +63,7 @@ def get_yaml_files(dags_folder: str) -> list[Path]:
 
     # Look if the file directly instantiates a BalancerConfiguration
     for path in base_path.glob("**/*.yaml"):
-        if path.is_file() and "_target_: airflow_config.Configuration" in path.read_text():
+        if path.is_file() and "_target_: airflow_config.Configuration" in _read_text(path):
             yamls.append(path)
     len_yamls = len(yamls)
     len_yamls_last = 0
@@ -45,7 +73,7 @@ def get_yaml_files(dags_folder: str) -> list[Path]:
             if path.is_file() and path not in yamls:
                 # Check and see if this references any existing yamls
                 for yaml in yamls:
-                    if path.parent == yaml.parent and f"{yaml.stem}@" in path.read_text():
+                    if path.parent == yaml.parent and f"{yaml.stem}@" in _read_text(path):
                         yamls.append(path)
                         break
         len_yamls_last = len_yamls

--- a/airflow_config/ui/standalone/__init__.py
+++ b/airflow_config/ui/standalone/__init__.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from ..functions import get_configs_from_yaml, get_yaml_files
+from ..functions import get_configs_from_yaml, get_dags_folder, get_yaml_files
 
 _static_path = Path(__file__).parent.parent.parent / "extension"
 _static_airflow_path = Path(__file__).parent / "static"
@@ -78,7 +78,7 @@ def build_app(*, dependencies: list[Any] | None = None) -> FastAPI:
 
     @app.get("/")
     async def home(request: Request):
-        dags_folder = os.environ.get("AIRFLOW__CORE__DAGS_FOLDER", os.environ.get("AIRFLOW_HOME", os.getcwd()))
+        dags_folder = get_dags_folder() or os.environ.get("AIRFLOW_HOME") or os.getcwd()
         yamls = get_yaml_files(dags_folder=dags_folder)
         if not yamls:
             return templates.TemplateResponse(request, "404.html", fab_common_mock)


### PR DESCRIPTION
Two bugs in the viewer that show up on MWAA, found while investigating why the plugin fails there.

### Airflow 3 never read `airflow.cfg` to find the dags folder

The two branches of `ui/airflow.py` resolved the dags folder differently. The Flask-AppBuilder path consulted `conf`; the FastAPI path did not:

| | fallback when `AIRFLOW__CORE__DAGS_FOLDER` is unset |
|---|---|
| Airflow 2 (FAB) | `conf.getsection("core").get("dags_folder")` |
| Airflow 3 (standalone) | `AIRFLOW_HOME`, i.e. the whole home directory |

So unless the env var was exported, Airflow 3 scanned all of `$AIRFLOW_HOME` instead of `$AIRFLOW_HOME/dags`. Measured on a live Airflow 2.11 host:

```
dags_folder (correct)            ->    0 yamls in    0.00s
AIRFLOW_HOME (the AF3 fallback)  ->   32 yamls in  126.70s
```

63,641 files walked. Behind a load balancer that is a timeout rather than a slow page, and the 32 results were unrelated test fixtures from installed source repos that happened to contain `_target_: airflow_config.Configuration`.

`get_dags_folder` now prefers the environment variable and otherwise reads the core section of the Airflow config. The standalone viewer keeps its `AIRFLOW_HOME`/cwd fallback so it still runs with no Airflow installed. This also removes an eager evaluation of `conf.getsection("core")` that ran even when the env var was set, and would have raised `AttributeError` had the section ever been missing.

### One unreadable file returned a 500

`get_yaml_files` called `path.read_text()` on every `*.yaml` under the dags folder with no encoding fallback and no error handling, and `home()` has no handler either. A single non-UTF-8 file anywhere under the dags folder took the whole page down:

```
get_yaml_files -> RAISES UnicodeDecodeError 'utf-8' codec can't decode byte 0xff
```

This matters most on MWAA, where the dags folder is an S3 sync and can contain anything that ends in `.yaml`. Unreadable files are now skipped.

### Notes

Both new tests fail on the current code and pass on this branch. Verified against real Airflow 2.11, where resolution returns `/var/lib/airflow/dags` rather than `/var/lib/airflow`.

Deliberately left alone, since nothing is currently broken by them and they would widen the diff:

- The `try`/`except ImportError` version gate. `airflow.www` does not exist in Airflow 3, so if any import in the `try` block shifts in a future 3.x, control falls into the `except` branch and dies on `from airflow.www.auth import has_access` — an uncaught `ImportError` that makes the plugin silently fail to register rather than erroring visibly. An explicit version check would be better.
- The `while` loop re-globs the entire tree on every pass, so it is O(n²) file reads on top of the walk.
- The glob matches `*.yaml` but never `*.yml`.
- `README.md` and `docs/src/examples.md` are not `ruff format` clean on main, unrelated to this change.

The same two fixes are in airflow-laminar/airflow-balancer, which duplicates this scanning code.